### PR TITLE
Avoid duplication in signed URL when specifying a version

### DIFF
--- a/lib/JIRA/REST/OAuth.pm
+++ b/lib/JIRA/REST/OAuth.pm
@@ -95,7 +95,7 @@ sub _generate_oauth_request
     }
 
     # generate oauth request url
-    my $url = $$self{url};
+    my $url = $self->{rest}->getHost;
     $url =~ s/\/$//;
     $url .= $path;
     my %oauth_params = (


### PR DESCRIPTION
Append the path to *just* the REST host, not the full `url` value, which might also contain the REST API path, as the latter results in duplication of the REST API path.

Resolves #2 